### PR TITLE
[feature/#57] Implement study group information edit functionality in EditStudyGroupPage

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -14,7 +14,8 @@ import ChatRoomListPage from "./pages/Chat/ChatRoomListPage.tsx";
 import ChatRoomPage from "./pages/Chat/ChatRoomPage.tsx";
 import PostListPage from "./pages/Community/PostListPage.tsx";
 import PostDetailPage from "./pages/Community/PostDetailPage.tsx";
-import MyPage from "./pages/Mypage/MyPage.tsx"
+import MyPage from "./pages/Mypage/MyPage.tsx";
+import EditStudyGroupPage from "./pages/Study/EditStudyGroupPage.tsx";
 
 function App() {
   return (
@@ -36,6 +37,7 @@ function App() {
           <Route path="/community" element={<PostListPage/>} />
           <Route path="/posts/:postId" element={<PostDetailPage />} />
           <Route path="/my-page" element={<MyPage />} />
+          <Route path="/study-groups/edit/:groupId" element={<EditStudyGroupPage />} />
         </Routes>
       </div>
     </Router>

--- a/src/api/studyGroupApi.ts
+++ b/src/api/studyGroupApi.ts
@@ -2,7 +2,6 @@ import axios from "axios";
 import { API_BASE_URL, authHeader, ApiResponse } from "./apiUtils.ts";
 import { transformStudyGroupData, transformStudyGroupFromResult } from "../utils/studyGroupUtils.ts";
 
-
 export interface StudyGroupDto {
   id?: number | null;
   category: string;
@@ -14,6 +13,14 @@ export interface StudyGroupDto {
   maxParticipants: number;
   isRecruiting?: boolean;
   myRole?: string;
+}
+
+export interface StudyGroupUpdateDto {
+  name: string;
+  description: string;
+  maxParticipants: number;
+  location: string;
+  category: string;
 }
 
 export interface StudyGroupMemberDto {
@@ -69,17 +76,20 @@ export const createStudyGroup = async (
   }
 };
 
-export const getCreatedStudyGroups = async (
-  accessToken: string
-): Promise<StudyGroupDto[]> => {
+export const updateGroupInfo = async (
+  accessToken: string, 
+  groupId: number,
+  studyGroupUpdateDto: StudyGroupUpdateDto
+) => {
   try {
-    const response = await axios.get<ApiResponse<StudyGroupDto[]>>(
-      `${API_BASE_URL}/study-groups/created-groups`, 
+    const response = await axios.patch<ApiResponse<string>>(
+      `${API_BASE_URL}/study-groups/${groupId}`,
+      studyGroupUpdateDto,
       authHeader(accessToken)
     );
-    return response.data.result!.map(transformStudyGroupData);
+    return response.data;
   } catch (error) {
-      throw new Error("스터디 그룹을 조회할 수 없습니다.");
+    throw new Error("스터디 그룹 정보 수정에 실패했습니다.");
   }
 };
 

--- a/src/components/studyGroup/StudyGroupDetailModal.tsx
+++ b/src/components/studyGroup/StudyGroupDetailModal.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from "react";
 import styled from "styled-components";
+import { useNavigate } from "react-router-dom";
 
 interface StudyGroupDetailModalProps {
   studyGroup: {
@@ -10,7 +11,7 @@ interface StudyGroupDetailModalProps {
     location: string;
     maxParticipants: number;
   };
-  groupId?: number;
+  groupId?: number | null;
   onJoin?: (groupId: number) => void;
   onClose: () => void;
   onCreateQuestionChatRoom?: (groupId: number) => void;
@@ -26,6 +27,7 @@ const StudyGroupDetailModal: React.FC<StudyGroupDetailModalProps> = ({
   sourcePage
 }) => {
 
+  const navigate = useNavigate();
   const [isDragging, setIsDragging] = useState(false);
   const [dragStart, setDragStart] = useState({ x: 0, y: 0 });
   const [modalPosition, setModalPosition] = useState({ x: 0, y: 0 });
@@ -96,9 +98,9 @@ const StudyGroupDetailModal: React.FC<StudyGroupDetailModalProps> = ({
             <ModalFooter>
               <FooterButton
                 onClick={() => {
-                  if (onCreateQuestionChatRoom && groupId !== undefined) {
+                  if (onCreateQuestionChatRoom && typeof groupId === 'number') {
                     onCreateQuestionChatRoom(groupId);
-                  }
+                  }                  
                 }}
               >
                 질문 채팅방 생성
@@ -106,7 +108,7 @@ const StudyGroupDetailModal: React.FC<StudyGroupDetailModalProps> = ({
               
               <FooterButton
                 onClick={() => {
-                  if (onJoin && groupId !== undefined) {
+                  if (onJoin && typeof groupId === 'number') {
                     onJoin(groupId);
                   }   
                 }}
@@ -116,6 +118,20 @@ const StudyGroupDetailModal: React.FC<StudyGroupDetailModalProps> = ({
             </ModalFooter>
           )}
 
+          {sourcePage === "LeaderStudyGroupPage" && (
+            <ModalFooter>
+              <FooterButton
+                onClick={() => {
+                  console.log(groupId);
+                  if (groupId !== undefined) {
+                    navigate(`/study-groups/edit/${groupId}`);
+                  }
+                }}
+              >
+                수정하기
+              </FooterButton>
+            </ModalFooter>
+          )}
         </ModalBody>
       </ModalContent>
     </ModalOverlay>

--- a/src/components/studyGroup/StudyGroupForm.tsx
+++ b/src/components/studyGroup/StudyGroupForm.tsx
@@ -1,0 +1,126 @@
+import React from "react";
+import { StudyGroupDto } from "../../api/studyGroupApi";
+import SelectableButton from "../ui/SelectableButton.tsx";
+import InputField from "../ui/InputField.tsx";
+import { locationMapping } from "../../constants/locationMapping.ts";
+import { studyCategoryMapping } from "../../constants/studyCategoryMapping.ts";
+import DatePicker from "./DatePicker.tsx";
+import Slider from "./Slider.tsx";
+
+interface StudyGroupFormProps {
+  formData: StudyGroupDto;
+  errors: any;
+  onInputChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  onCategoryChange: (category: string) => void;
+  onLocationChange: (location: string) => void;
+  onMaxParticipantsChange: (value: number) => void;
+  onDateChange: (start: string, end: string) => void;
+  onSubmit: () => void;
+  submitLabel: string;
+}
+
+const StudyGroupForm: React.FC<StudyGroupFormProps> = ({
+  formData,
+  errors,
+  onInputChange,
+  onCategoryChange,
+  onLocationChange,
+  onMaxParticipantsChange,
+  onDateChange,
+  onSubmit,
+  submitLabel,
+}) => {
+  return (
+    <div className="createStudyGroupPage">
+      {errors.general && <p className="error">{errors.general}</p>}
+
+      <div className="formGroup">
+        <label className="label">진행 방식</label>
+        <div className="buttonGroup">
+          <SelectableButton
+            label="온라인"
+            isSelected={formData.isOnline}
+            onClick={() => onLocationChange("online")}
+          />
+          <SelectableButton
+            label="오프라인"
+            isSelected={!formData.isOnline}
+            onClick={() => onLocationChange("")}
+          />
+        </div>
+      </div>
+
+      <div className="formGroup">
+        <label className="label">스터디 진행 장소</label>
+        <div className="buttonGroup">
+          {Object.entries(locationMapping).map(([key, label]) => (
+            <SelectableButton
+              key={key}
+              label={label}
+              isSelected={formData.location === key}
+              onClick={() => onLocationChange(key)}
+            />
+          ))}
+        </div>
+      </div>
+
+      <div className="formGroup">
+        <label className="label">스터디 카테고리</label>
+        <div className="buttonGroup">
+          {Object.entries(studyCategoryMapping).map(([key, label]) => (
+            <SelectableButton
+              key={key}
+              label={label}
+              isSelected={formData.category === key}
+              onClick={() => onCategoryChange(key)}
+            />
+          ))}
+        </div>
+      </div>
+
+      <div className="formGroup">
+        <label className="label">스터디 이름</label>
+        <InputField
+          type="text"
+          name="name"
+          placeholder="스터디 이름을 입력하세요"
+          value={formData.name}
+          onChange={onInputChange}
+        />
+      </div>
+
+      <div className="formGroup">
+        <label className="label">스터디 설명</label>
+        <InputField
+          type="text"
+          name="description"
+          placeholder="스터디 설명을 입력하세요"
+          value={formData.description}
+          onChange={onInputChange}
+        />
+      </div>
+
+      <div className="formGroup">
+        <label className="label">진행 기간</label>
+        <DatePicker onDateChange={onDateChange} />
+        <p className="infoText">현재 기간: {formData.duration}</p>
+      </div>
+
+      <div className="formGroup">
+        <label className="label">최대 참여자 수</label>
+        <Slider
+          min={1}
+          max={20}
+          value={formData.maxParticipants}
+          onChange={onMaxParticipantsChange}
+        />
+      </div>
+
+      <button className="submitButton" onClick={onSubmit}>
+        {submitLabel}
+      </button>
+    </div>
+  );
+};
+
+export default StudyGroupForm;

--- a/src/constants/locationMapping.ts
+++ b/src/constants/locationMapping.ts
@@ -16,4 +16,4 @@ export const locationMapping: { [key: string]: string } = {
   ULSAN: "울산광역시",
   BUSAN: "부산광역시",
   OTHERS: "기타"
-};
+};   

--- a/src/hooks/useStudyGroupForm.ts
+++ b/src/hooks/useStudyGroupForm.ts
@@ -1,0 +1,52 @@
+import { useState } from "react";
+
+export interface StudyGroupDto {
+  category: string;
+  name: string;
+  description: string;
+  duration: string;
+  location: string;
+  maxParticipants: number;
+  isOnline: boolean;
+}
+
+const useStudyGroupForm = (initialState: StudyGroupDto) => {
+  const [formData, setFormData] = useState<StudyGroupDto>(initialState);
+
+  const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const { name, value } = e.target;
+    setFormData(prev => ({ ...prev, [name]: value }));
+  };
+
+  const handleCategoryChange = (category: string) => {
+    setFormData(prev => ({ ...prev, category }));
+  };
+
+  const handleLocationChange = (location: string) => {
+    setFormData(prev => ({
+      ...prev,
+      location,
+      isOnline: location === "online",
+    }));
+  };
+
+  const handleMaxParticipantsChange = (value: number) => {
+    setFormData(prev => ({ ...prev, maxParticipants: value }));
+  };
+
+  const handleDateChange = (start: string, end: string) => {
+    setFormData(prev => ({ ...prev, duration: `${start} ~ ${end}` }));
+  };
+
+  return {
+    formData,
+    setFormData,
+    handleInputChange,
+    handleCategoryChange,
+    handleLocationChange,
+    handleMaxParticipantsChange,
+    handleDateChange,
+  };
+};
+
+export default useStudyGroupForm;

--- a/src/pages/Mypage/MyPage.css
+++ b/src/pages/Mypage/MyPage.css
@@ -103,3 +103,35 @@
 .cancel-btn:hover {
   background-color: #777;
 }
+
+.study-group-section {
+  margin-top: 40px; 
+}
+
+.study-group-title {
+  font-size: 1.2rem;
+  font-weight: 700;
+  margin-top: 70px;
+  margin-bottom: -25px;
+  color: #555;
+}
+
+.study-group-row {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 8px;
+  padding: 10px 0;
+}
+
+.tag-box {
+  background-color: #55555518;
+  border: 1px solid #55555588;
+  border-radius: 4px;
+  padding: 3px 8px;
+  font-size: 0.8rem;
+  color: #777;
+  user-select: none;
+  white-space: nowrap;
+  margin-right: 10px;
+}

--- a/src/pages/Mypage/MyPage.tsx
+++ b/src/pages/Mypage/MyPage.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from "react";
-import { getMemberProfile, updateMemberProfile, MemberDto, MemberUpdateDto } from "../../api/myPageApi.ts";
+import { getMemberProfile, MemberDto } from "../../api/myPageApi.ts";
+import { getAllStudyGroupsWithStatus, StudyGroupDto } from "../../api/studyGroupApi.ts"; // 스터디 API
 import { Header } from "../../components/layout/Header.tsx";
 import { locationMapping } from "../../constants/locationMapping.ts";
 import EditProfileModal from "../../components/myPage/EditProfileModal.tsx";
@@ -8,6 +9,7 @@ import "./MyPage.css";
 
 const MyPage: React.FC = () => {
   const [profile, setProfile] = useState<MemberDto | null>(null);
+  const [studyGroups, setStudyGroups] = useState<StudyGroupDto[]>([]);
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [error, setError] = useState<string>("");
 
@@ -24,6 +26,24 @@ const MyPage: React.FC = () => {
     };
     fetchProfile();
   }, [accessToken]);
+
+  useEffect(() => {
+    const fetchStudyGroups = async () => {
+      try {
+        const groups = await getAllStudyGroupsWithStatus(accessToken);
+        setStudyGroups(groups);
+      } catch {
+        setError("스터디 그룹 정보를 불러오지 못했습니다.");
+      }
+    };
+    fetchStudyGroups();
+  }, [accessToken]);
+
+  const activeGroups = studyGroups.filter(
+    (g) => g.myRole === "LEADER" || g.myRole === "MEMBER"
+  );
+
+  const requestedGroups = studyGroups.filter((g) => g.myRole === "REQUESTED");
 
   return (
     <>
@@ -90,21 +110,63 @@ const MyPage: React.FC = () => {
                   수정
                 </button>
               </div>
+            </div>
 
-              {isModalOpen && (
-                <EditProfileModal
-                  profile={profile}
-                  onClose={() => setIsModalOpen(false)}
-                  onSaveSuccess={(updated) => {
-                    setProfile(updated);
-                    setIsModalOpen(false);
-                  }}
-                />
-              )}
+            <h3 className="study-group-title">활동 중인 스터디 그룹</h3>
+
+            <div className="study-group-section"> 
+              <hr className="row-divider" />
+              {activeGroups.length === 0 && <div>활동 중인 스터디 그룹이 없습니다.</div>}
+              {activeGroups.map((group) => (
+                <div key={group.id}>
+                  <div className="profile-row">
+                    <div className="profile-label">{group.name}</div>
+                    <div className="profile-value">
+                      <span className="tag-box">#{group.myRole}</span>{' '}
+                      <span className="tag-box">#{group.category}</span>{' '}
+                      <span className="tag-box">#{group.location}</span>{' '}
+                      <span className="tag-box">#{group.duration}</span>
+                    </div>
+                  </div>
+                  <hr className="row-divider" />
+                </div>
+              ))}
+            </div>
+
+            <h3 className="study-group-title">가입 요청 보낸 스터디 그룹</h3>
+
+            <div className="study-group-section"> 
+              <hr className="row-divider" />
+              {requestedGroups.length === 0 && <div>가입 요청을 보낸 스터디 그룹이 없습니다.</div>}
+              {requestedGroups.map((group) => (
+                <div key={group.id}>
+                  <div className="profile-row">
+                    <div className="profile-label">{group.name}</div>
+                    <div className="profile-value">
+                      <span className="tag-box">#{group.myRole}</span>{' '}
+                      <span className="tag-box">#{group.category}</span>{' '}
+                      <span className="tag-box">#{group.location}</span>{' '}
+                      <span className="tag-box">#{group.duration}</span>
+                    </div>
+                  </div>
+                  <hr className="row-divider" />
+                </div>
+              ))}
             </div>
           </>
         )}
       </div>
+
+      {isModalOpen && profile && (
+        <EditProfileModal
+          profile={profile}
+          onClose={() => setIsModalOpen(false)}
+          onSaveSuccess={(updated) => {
+            setProfile(updated);
+            setIsModalOpen(false);
+          }}
+        />
+      )}
     </>
   );
 };

--- a/src/pages/Study/CreateStudyGroupPage.css
+++ b/src/pages/Study/CreateStudyGroupPage.css
@@ -4,12 +4,12 @@
   text-align: center;
 }
   
-.createStudyGroupPage .title {
+.createStudyGroupPage-title {
   color: #555;
   font-size: 30px;
   margin-bottom: 60px;
   margin-top: 100px;
-  margin-left: -370px;
+  margin-left: 250px;
 }
   
 .createStudyGroupPage .error {

--- a/src/pages/Study/CreateStudyGroupPage.tsx
+++ b/src/pages/Study/CreateStudyGroupPage.tsx
@@ -1,17 +1,14 @@
-import React, { useState } from "react";
-import InputField from "../../components/ui/InputField.tsx";
-import SelectableButton from "../../components/ui/SelectableButton.tsx";
-import Slider from "../../components/studyGroup/Slider.tsx";
-import DatePicker from "../../components/studyGroup/DatePicker.tsx";
+import React from "react";
+import { createStudyGroup, StudyGroupDto } from "../../api/studyGroupApi.ts";
+import StudyGroupForm from "../../components/studyGroup/StudyGroupForm.tsx";
 import Modal from "../../components/ui/Modal.tsx";
-import { createStudyGroup, StudyGroupDto } from "../../api/studyGroupApi.ts"; 
-import { studyCategoryMapping } from "../../constants/studyCategoryMapping.ts";
-import { locationMapping } from "../../constants/locationMapping.ts";
 import { useModal } from "../../hooks/useModal.ts";
-import './CreateStudyGroupPage.css';
+import useStudyGroupForm from "../../hooks/useStudyGroupForm.ts";
+
+import "./CreateStudyGroupPage.css";
 
 const CreateStudyGroupPage = () => {
-  const [formData, setFormData] = useState<StudyGroupDto>({
+  const initialFormData: StudyGroupDto = {
     category: "",
     name: "",
     description: "",
@@ -19,30 +16,28 @@ const CreateStudyGroupPage = () => {
     location: "",
     maxParticipants: 5,
     isOnline: false,
-  });
-
-  const [errors, setErrors] = useState<any>({});
-  const { isModalOpen, setIsModalOpen, modalMessage, setModalMessage, handleCloseModal, handleGoHome, handleGoLogin, handleGoStudyGroup } = useModal();
-
-  const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    setFormData({ ...formData, [e.target.name]: e.target.value });
   };
 
-  const handleCategoryChange = (category: string) => {
-    setFormData({ ...formData, category });
-  };
+  const {
+    formData,
+    setFormData,
+    handleInputChange,
+    handleCategoryChange,
+    handleDateChange,
+    handleLocationChange,
+    handleMaxParticipantsChange,
+  } = useStudyGroupForm(initialFormData);
 
-  const handleLocationChange = (location: string) => {
-    setFormData({ ...formData, location });
-  };
-
-  const handleMaxParticipantsChange = (value: number) => {
-    setFormData({ ...formData, maxParticipants: value });
-  };
-
-  const handleDateChange = (start: string, end: string) => {
-    setFormData({ ...formData, duration: `${start} ~ ${end}` });
-  };
+  const [errors, setErrors] = React.useState<any>({});
+  const {
+    isModalOpen,
+    setIsModalOpen,
+    modalMessage,
+    setModalMessage,
+    handleCloseModal,
+    handleGoHome,
+    handleGoStudyGroup,
+  } = useModal();
 
   const handleCreateStudyGroup = async () => {
     const accessToken = localStorage.getItem("accessToken");
@@ -52,19 +47,11 @@ const CreateStudyGroupPage = () => {
     }
 
     try {
-      const response = await createStudyGroup(accessToken, formData); 
+      const response = await createStudyGroup(accessToken, formData);
       if (response.isSuccess) {
         setModalMessage("스터디 그룹 생성이 완료되었습니다.");
         setIsModalOpen(true);
-        setFormData({
-          category: "",
-          name: "",
-          description: "",
-          duration: "",
-          location: "",
-          maxParticipants: 5,
-          isOnline: false,
-        });
+        setFormData(initialFormData);  
       } else {
         setErrors({ general: response.message || "스터디 그룹 생성에 실패했습니다." });
       }
@@ -74,91 +61,19 @@ const CreateStudyGroupPage = () => {
   };
 
   return (
-    <div className="createStudyGroupPage">
-      <h1 className="title">스터디 그룹 생성</h1>
-
-      {errors.general && <p className="error">{errors.general}</p>}
-
-      <div className="formGroup">
-        <label className="label">진행 방식</label>
-        <div className="buttonGroup">
-          <SelectableButton
-            label="온라인"
-            isSelected={formData.isOnline}
-            onClick={() => setFormData({ ...formData, isOnline: true })}
-          />
-          <SelectableButton
-            label="오프라인"
-            isSelected={!formData.isOnline}
-            onClick={() => setFormData({ ...formData, isOnline: false })}
-          />
-        </div>
-      </div>
-
-      <div className="formGroup">
-        <label className="label">스터디 진행 장소</label>
-        <div className="buttonGroup">
-          {Object.entries(locationMapping).map(([key, label]) => (
-            <SelectableButton
-              key={key}
-              label={label}
-              isSelected={formData.location === key}
-              onClick={() => handleLocationChange(key)}
-            />
-          ))}
-        </div>
-      </div>
-
-      <div className="formGroup">
-        <label className="label">스터디 카테고리</label>
-        <div className="buttonGroup">
-          {Object.entries(studyCategoryMapping).map(([key, label]) => (
-            <SelectableButton
-              key={key}
-              label={label}
-              isSelected={formData.category === key}
-              onClick={() => handleCategoryChange(key)}
-            />
-          ))}
-        </div>
-      </div>
-
-      <div className="formGroup">
-        <label className="label">스터디 이름</label>
-        <InputField
-          type="text"
-          name="name"
-          placeholder="스터디 이름을 입력하세요"
-          value={formData.name}
-          onChange={handleInputChange}
-        />
-      </div>
-
-      <div className="formGroup">
-        <label className="label">스터디에 대한 설명</label>
-        <InputField
-          type="text"
-          name="description"
-          placeholder="스터디 설명을 입력하세요"
-          value={formData.description}
-          onChange={handleInputChange}
-        />
-      </div>
-
-      <div className="formGroup">
-        <label className="label">진행 기간</label>
-        <DatePicker onDateChange={handleDateChange} />
-      </div>
-
-      <div className="formGroup">
-        <label className="label">최대 참여자 수</label>
-        <Slider min={1} max={20} value={formData.maxParticipants} onChange={handleMaxParticipantsChange} />
-      </div>
-
-      <button className="submitButton" onClick={handleCreateStudyGroup}>
-        스터디 그룹 생성
-      </button>
-
+    <>
+      <h1 className="createStudyGroupPage-title">스터디 그룹 생성</h1>
+      <StudyGroupForm
+        formData={formData}
+        errors={errors}
+        onInputChange={handleInputChange}
+        onCategoryChange={handleCategoryChange}
+        onLocationChange={handleLocationChange}
+        onMaxParticipantsChange={handleMaxParticipantsChange}
+        onDateChange={handleDateChange}
+        onSubmit={handleCreateStudyGroup}
+        submitLabel="스터디 그룹 생성"
+      />
       {isModalOpen && (
         <Modal
           message={modalMessage}
@@ -168,8 +83,8 @@ const CreateStudyGroupPage = () => {
           type="studyGroup"
         />
       )}
-    </div>
+    </>
   );
 };
 
-export default CreateStudyGroupPage;
+  export default CreateStudyGroupPage;

--- a/src/pages/Study/EditStudyGroupPage.tsx
+++ b/src/pages/Study/EditStudyGroupPage.tsx
@@ -1,0 +1,113 @@
+import React, { useEffect, useState } from "react";
+import { useParams } from "react-router-dom";
+import StudyGroupForm from "../../components/studyGroup/StudyGroupForm.tsx";
+import { getStudyGroupById, updateGroupInfo, StudyGroupDto, StudyGroupUpdateDto } from "../../api/studyGroupApi.ts";
+import Modal from "../../components/ui/Modal.tsx";
+import useStudyGroupForm from "../../hooks/useStudyGroupForm.ts";
+import { useModal } from "../../hooks/useModal.ts";
+import { locationMapping } from "../../constants/locationMapping.ts";
+import { studyCategoryMapping } from "../../constants/studyCategoryMapping.ts";
+
+const EditStudyGroupPage = () => {
+    const { groupId } = useParams();
+
+    const initialFormData: StudyGroupDto = {
+      category: "",
+      name: "",
+      description: "",
+      duration: "",
+      location: "",
+      maxParticipants: 5,
+      isOnline: false,
+    };
+  
+    const {
+      formData,
+      setFormData,
+      handleInputChange,
+      handleCategoryChange,
+      handleDateChange,
+      handleLocationChange,
+      handleMaxParticipantsChange,
+    } = useStudyGroupForm(initialFormData);
+
+  const [errors, setErrors] = useState<any>({});
+  const { isModalOpen, setIsModalOpen, modalMessage, setModalMessage, handleCloseModal, handleGoHome, handleGoStudyGroup } = useModal();
+
+  useEffect(() => {
+    const fetchStudyGroup = async () => {
+      try {
+        if (!groupId) return;
+        const data = await getStudyGroupById(Number(groupId));
+        setFormData({
+          ...data,
+          isOnline: data.location === "online",
+        });
+      } catch (err) {
+        setErrors({ general: "스터디 정보를 불러오지 못했습니다." });
+      }
+    };
+
+    fetchStudyGroup();
+  }, [groupId]);
+
+  const findKeyByValue = (mapping: { [key: string]: string }, value: string): string | undefined => {
+    return Object.entries(mapping).find(([key, val]) => val === value)?.[0];
+  };
+
+  const handleUpdateStudyGroup = async () => {
+    const accessToken = localStorage.getItem("accessToken");
+    if (!accessToken || !groupId) {
+      setErrors({ general: "로그인이 필요합니다." });
+      return;
+    }
+
+    const updateDto: StudyGroupUpdateDto = {
+      name: formData.name,
+      description: formData.description,
+      maxParticipants: formData.maxParticipants,
+      location: findKeyByValue(locationMapping, formData.location) ?? formData.location,
+      category: findKeyByValue(studyCategoryMapping, formData.category) ?? formData.category,
+    };
+
+    try {
+      const response = await updateGroupInfo(accessToken, Number(groupId), updateDto);
+      if (response.isSuccess) {
+        setModalMessage("스터디 그룹 정보가 성공적으로 수정되었습니다.");
+        setIsModalOpen(true);
+      } else {
+        setErrors({ general: response.message || "수정에 실패했습니다." });
+      }
+    } catch (err) {
+      setErrors({ general: "스터디 그룹 수정 중 오류가 발생했습니다." });
+    }
+  };
+
+  return (
+    <>
+      <h1 className="createStudyGroupPage-title">스터디 그룹 수정</h1>
+      <StudyGroupForm
+        formData={formData}
+        errors={errors}
+        onInputChange={handleInputChange}
+        onCategoryChange={handleCategoryChange}
+        onLocationChange={handleLocationChange}
+        onMaxParticipantsChange={handleMaxParticipantsChange}
+        onDateChange={handleDateChange}
+        onSubmit={handleUpdateStudyGroup}
+        submitLabel="수정 완료"
+      />
+      {isModalOpen && (
+        <Modal
+          message={modalMessage}
+          onClose={handleCloseModal}
+          onConfirmHome={handleGoHome}
+          onConfirmStudyGroup={handleGoStudyGroup}
+          type="studyGroup"
+        />
+      )}
+    </>
+  );
+};
+
+export default EditStudyGroupPage;

--- a/src/pages/Study/LeaderStudyGroupPage.tsx
+++ b/src/pages/Study/LeaderStudyGroupPage.tsx
@@ -12,6 +12,7 @@ import { useModal } from "../../hooks/useModal.ts";
 import "./StudyGroupPage.css";
 
 interface StudyGroupDetail {
+  id?: number | null;
   category: string;
   name: string;
   description: string;
@@ -27,7 +28,6 @@ export const LeaderStudyGroupPage: React.FC = () => {
   const [selectedGroup, setSelectedGroup] = useState<StudyGroupDetail | null>(null);
   const [memberModalOpen, setMemberModalOpen] = useState(false); 
   const [selectedGroupIdForMember, setSelectedGroupIdForMember] = useState<number | null>(null); 
-  const [closedGroups, setClosedGroups] = useState<number[]>([]);
   const [error, setError] = useState<string | null>(null);
   const [createdChatRooms, setCreatedChatRooms] = useState<number[]>([]);
 
@@ -173,6 +173,7 @@ export const LeaderStudyGroupPage: React.FC = () => {
       {isModalOpen && selectedGroup && (
         <StudyGroupDetailModal 
           studyGroup={selectedGroup}
+          groupId={selectedGroup.id}
           onClose={handleCloseModal}
           sourcePage="LeaderStudyGroupPage"
         />


### PR DESCRIPTION
### To-Do List

- [x] Implement study group information editing functionality in EditStudyGroupPage.
- [x] Add routing for EditStudyGroupPage in App.tsx.
- [x] Integrate API for updating study group information in studyGroupApi.
- [x] Enable navigation to the edit page from StudyGroupDetailModal.
- [x] Add functionality to display active and requested study groups.
- [x] Rename CSS class for title styling in CreateStudyGroupPage.
- [x] Update StudyGroupDetailModal to accept groupId as a prop.
- [x] Create reusable StudyGroupForm component for study group creation and editing pages.
- [x] Create reusable useStudyGroupForm hook for managing form logic in study group create/edit pages.
- [x] Apply reusable StudyGroupForm component and useStudyGroupForm hook in the study group creation page.

closed #57